### PR TITLE
Content script test

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,5 @@
     "http://open.spotify.com/track/*",
     "https://open.spotify.com/track/*"
   ],
-  "permissions": ["storage", "scripting", "activeTab", "tabs"]
+  "permissions": ["storage", "scripting", "activeTab"]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -18,16 +18,5 @@
     "http://open.spotify.com/track/*",
     "https://open.spotify.com/track/*"
   ],
-  "content_scripts": [
-    {
-      "matches": [
-        "http://open.spotify.com/track/*",
-        "https://open.spotify.com/track/*"
-      ],
-      "js": ["src/script.ts"],
-      "all_frames": true,
-      "run_at": "document_start"
-    }
-  ],
   "permissions": ["storage", "scripting", "activeTab", "tabs"]
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "parcel watch manifest.json --host localhost",
+    "dev": "parcel watch --host localhost",
     "build": "parcel build"
   },
   "source": [

--- a/package.json
+++ b/package.json
@@ -5,8 +5,12 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "parcel watch manifest.json --host localhost",
-    "build": "parcel build manifest.json"
+    "build": "parcel build"
   },
+  "source": [
+    "src/script.ts",
+    "manifest.json"
+  ],
   "@parcel/resolver-default": {
     "packageExports": true
   },

--- a/src/background.ts
+++ b/src/background.ts
@@ -6,7 +6,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   ) {
     chrome.scripting.executeScript({
       target: { tabId: tabId },
-      files: ['script.js'],
+      files: ['src/script.js'],
     })
   }
 })


### PR DESCRIPTION
- Removed `tabs` permission, only need `activeTab`
- Removed content_script field in manifest, unnecessary since executing script using `scripting` permission
- Added script as entry point